### PR TITLE
renamed _layout/redirect.html to redirect_deprecated.html 

### DIFF
--- a/_layouts/redirect_deprecated.html
+++ b/_layouts/redirect_deprecated.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+
+    <head>
+    	<meta charset="utf-8">
+    	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+    	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    	<title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+        {% include redirect_code.html %}
+
+    	<link rel="stylesheet" href="{{ site.baseurl }}/lib/main.css">
+    	<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+    	<link rel="stylesheet" href="{{ site.baseurl }}/bootstrap/css/bootstrap.min.css">
+    	<link rel="stylesheet" href="{{ site.baseurl }}/bootstrap/css/bootstrap-theme.min.css">
+    	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+    	<meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:site" content="@VEsinFiltro">
+        <meta name="twitter:creator" content="@VEinteligente">
+        <meta name="twitter:title" content="{% if page.small %}{{ page.small }}{% else %}{% if page.title %}{{ page.title }}{% else %}VEsinFiltro.com reporta y evade la censura{% endif %}{% endif %}">
+        <meta name="twitter:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | truncatewords:75  }}{% else %}¡Que no te censuren el internet! Reporta fallas, bloqueo y censura en internet; y navega librevente siguiendo nuestros tutoriales{% endif %}">
+        <meta name="twitter:image" content="{% if page.image == "no" %}{{ "/res/TWcard.png" | absolute_url }}{% else %}{{ page.image | absolute_url }}{% endif %}">
+    </head>
+
+  <body class="{{page.bodyclass}}">
+
+    {% include header.html %}
+
+    <div class="page-content">
+	  <header class="wrapper post-header">
+        <h1 class="post-title">{{ page.title }}</h1>
+      </header>
+      <div class="wrapper"><div>
+        <div class="post">
+          <article class="post-content">
+            {{ content }}
+          </article>
+         </div>
+      </div></div>
+    </div>
+
+    {% include footer.html %}
+
+    Si no eres redigido a run.ooni.io [haz click aqui.]({{site.destination}})
+
+  </body>
+
+</html>


### PR DESCRIPTION
the plugin jekyll-redirect-from needs a template file named "redirect.html" to create the redirections. Since there was a file with the same name in _layouts,  jekyll gets confused and uses this file instead of its own template. This ended in an empty url while redirecting so it got stucked in a redirect loop.